### PR TITLE
Removed max verion for nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://HerdHound@github.com/HerdHound/node-logging.git"
   },
   "engines": {
-    "node": ">= 0.4.1 < 0.5.0"
+    "node": ">= 0.4.1"
   },
   "dependencies": {
     "colors": ">= 0.5.0"


### PR DESCRIPTION
its working with 0.6, should not set this. people will tell you if this is not working :)
